### PR TITLE
Easier connection to RocketPool

### DIFF
--- a/docker-compose-with-clients-metrics.yml
+++ b/docker-compose-with-clients-metrics.yml
@@ -51,6 +51,10 @@ services:
       - ./prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
+    networks:
+      default:
+        aliases:
+          - vc-rkm
 
   reloader:
     image: diva/reloader:v23.8.0
@@ -61,7 +65,7 @@ services:
     volumes:
       - ./prysm/validator/jwt:/jwt
     environment:
-      - VALIDATOR_RKM_API=http://validator:7500
+      - VALIDATOR_RKM_API=http://vc-rkm:7500
       - DIVA_W3S_API=http://diva:9000
       - SYNC_PERIOD=600
 

--- a/docker-compose-with-clients.yml
+++ b/docker-compose-with-clients.yml
@@ -51,6 +51,10 @@ services:
       - ./prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
+    networks:
+      default:
+        aliases:
+          - vc-rkm
 
   reloader:
     image: diva/reloader:v23.8.0
@@ -61,7 +65,7 @@ services:
     volumes:
       - ./prysm/validator/jwt:/jwt
     environment:
-      - VALIDATOR_RKM_API=http://validator:7500
+      - VALIDATOR_RKM_API=http://vc-rkm:7500
       - DIVA_W3S_API=http://diva:9000
       - SYNC_PERIOD=600
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       - ./prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
+    networks:
+      default:
+        aliases:
+          - vc-rkm
 
   reloader:
     image: diva/reloader:v23.8.0
@@ -61,7 +65,7 @@ services:
     volumes:
       - ./prysm/validator/jwt:/jwt
     environment:
-      - VALIDATOR_RKM_API=http://validator:7500
+      - VALIDATOR_RKM_API=http://vc-rkm:7500
       - DIVA_W3S_API=http://diva:9000
       - SYNC_PERIOD=600
 

--- a/ext-network.yml
+++ b/ext-network.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+
+networks:
+  default:
+    name: rocketpool_net
+    external: true


### PR DESCRIPTION
This bears some explanation

Users on Diva Discord have been trying - with varied success - to connect the Diva stack with RocketPool and Eth Docker, with the CL and EL running there, instead of Diva.

The obvious answer is something like the `ext-network.yml` included here into `COMPOSE_FILE`. At that point however, Docker DNS creates issues for the reloader: Both RocketPool and Eth Docker also have a service called `validator`. I work around this by creating an alias `vc-rkm` that the reloader can connect to.

Strictly speaking this alias will only ever be needed in `docker-compose.yml`, but I also added it to `docker-compose-with-clients.yml` for consistency's sake.

This PR should serve as a discussion point - unless you see the obvious value and merge it right away that is ;)
