### PR TITLE
✨ add an optional config value to set data directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,6 @@ DIVA_API_KEY=changeThis  # Change this (API key for the operator UI)
 DIVA_VAULT_PASSWORD=vaultPassword # Change this (password for the encrypted vault)
 TESTNET_USERNAME=username-address  # Change this (recommended to username of the operator and ethereum address)
 
-# Optional: the path where you want to store the data of Diva and potentially the consensus and executin clients managed by it's stack
+# Optional: the path where you want to store the data of Diva and potentially the consensus and execution clients managed by it's stack
 # default value when this variable is unset is the current directory
 DIVA_DATA_FOLDER=

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ BEACON_RPC_PROVIDER=HOST_IP:PORT # Change this (consensus RPC, prysm example: h
 DIVA_API_KEY=changeThis  # Change this (API key for the operator UI)
 DIVA_VAULT_PASSWORD=vaultPassword # Change this (password for the encrypted vault)
 TESTNET_USERNAME=username-address  # Change this (recommended to username of the operator and ethereum address)
+
+# Optional: the path where you want to store the data of Diva and potentially the consensus and executin clients managed by it's stack
+# default value when this variable is unset is the current directory
+DIVA_DATA_FOLDER=

--- a/docker-compose-with-clients-metrics.yml
+++ b/docker-compose-with-clients-metrics.yml
@@ -22,7 +22,7 @@ services:
       - OTEL_EXPORTER_JAEGER_AGENT_HOST=jaeger
       - OTEL_EXPORTER_JAEGER_AGENT_PORT=6831
     volumes:
-      - ./.diva/data/:/opt/diva/data/
+      - ${DIVA_DATA_FOLDER:-.}/.diva/data/:/opt/diva/data/
     ports:
       - 127.0.0.1:9000:9000
       - 5050:5050
@@ -46,9 +46,9 @@ services:
         "--grpc-gateway-host=0.0.0.0",
       ]
     volumes:
-      - ./prysm/validator/config:/config
-      - ./prysm/validator/data/validator:/data
-      - ./prysm/validator/jwt:/jwt
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/config:/config
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/data/validator:/data
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
 
@@ -112,8 +112,8 @@ services:
         "--authrpc.jwtsecret=/opt/config/jwt",
       ]
     volumes:
-      - "./geth:/root/.ethereum"
-      - "./geth/config:/opt/config"
+      - "${DIVA_DATA_FOLDER:-.}/geth:/root/.ethereum"
+      - "${DIVA_DATA_FOLDER:-.}/geth/config:/opt/config"
     ports:
       - 127.0.0.1:8546:8546
       - 127.0.0.1:8551:8551
@@ -143,8 +143,8 @@ services:
         "--monitoring-host=0.0.0.0"
       ]
     volumes:
-      - "./prysm/beacon/data:/opt/prysm/data"
-      - "./geth/config:/opt/config"
+      - "${DIVA_DATA_FOLDER:-.}/prysm/beacon/data:/opt/prysm/data"
+      - "${DIVA_DATA_FOLDER:-.}/geth/config:/opt/config"
     ports:
       - 13000:13000/tcp
       - 12000:12000/udp
@@ -162,8 +162,8 @@ services:
     ports:
       - 127.0.0.1:9090:9090
     volumes:
-      - ./prometheus/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml
-      - ./prometheus/data:/prometheus
+      - ${DIVA_DATA_FOLDER:-.}/prometheus/prometheus/prometheus.yaml:/etc/prometheus/prometheus.yml
+      - ${DIVA_DATA_FOLDER:-.}/prometheus/data:/prometheus
 
   node-exporter:
     image: prom/node-exporter:v1.6.1
@@ -181,6 +181,6 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./grafana/config:/etc/grafana/provisioning
-      - ./grafana/data:/var/lib/grafana
-      - ./grafana/config/grafana.ini:/etc/grafana/grafana.ini
+      - ${DIVA_DATA_FOLDER:-.}/grafana/config:/etc/grafana/provisioning
+      - ${DIVA_DATA_FOLDER:-.}/grafana/data:/var/lib/grafana
+      - ${DIVA_DATA_FOLDER:-.}/grafana/config/grafana.ini:/etc/grafana/grafana.ini

--- a/docker-compose-with-clients.yml
+++ b/docker-compose-with-clients.yml
@@ -22,7 +22,7 @@ services:
       - OTEL_EXPORTER_JAEGER_AGENT_HOST=jaeger
       - OTEL_EXPORTER_JAEGER_AGENT_PORT=6831
     volumes:
-      - ./.diva/data/:/opt/diva/data/
+      - ${DIVA_DATA_FOLDER:-.}/.diva/data/:/opt/diva/data/
     ports:
       - 127.0.0.1:9000:9000
       - 5050:5050
@@ -46,9 +46,9 @@ services:
         "--grpc-gateway-host=0.0.0.0",
       ]
     volumes:
-      - ./prysm/validator/config:/config
-      - ./prysm/validator/data/validator:/data
-      - ./prysm/validator/jwt:/jwt
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/config:/config
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/data/validator:/data
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
 
@@ -59,7 +59,7 @@ services:
     hostname: reloader
     restart: unless-stopped
     volumes:
-      - ./prysm/validator/jwt:/jwt
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/jwt:/jwt
     environment:
       - VALIDATOR_RKM_API=http://validator:7500
       - DIVA_W3S_API=http://diva:9000
@@ -112,8 +112,8 @@ services:
         "--authrpc.jwtsecret=/opt/config/jwt",
       ]
     volumes:
-      - "./geth:/root/.ethereum"
-      - "./geth/config:/opt/config"
+      - "${DIVA_DATA_FOLDER:-.}/geth:/root/.ethereum"
+      - "${DIVA_DATA_FOLDER:-.}/geth/config:/opt/config"
     ports:
       - 127.0.0.1:8546:8546
       - 127.0.0.1:8551:8551
@@ -143,8 +143,8 @@ services:
         "--monitoring-host=0.0.0.0"
       ]
     volumes:
-      - "./prysm/beacon/data:/opt/prysm/data"
-      - "./geth/config:/opt/config"
+      - "${DIVA_DATA_FOLDER:-.}/prysm/beacon/data:/opt/prysm/data"
+      - "${DIVA_DATA_FOLDER:-.}/geth/config:/opt/config"
     ports:
       - 13000:13000/tcp
       - 12000:12000/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
         "--grpc-gateway-host=0.0.0.0",
       ]
     volumes:
-      - ./prysm/validator/config:/config
-      - ./prysm/validator/data/validator:/data
-      - ./prysm/validator/jwt:/jwt
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/config:/config
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/data/validator:/data
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/jwt:/jwt
     ports:
       - 127.0.0.1:7500:7500
 
@@ -59,7 +59,7 @@ services:
     hostname: reloader
     restart: unless-stopped
     volumes:
-      - ./prysm/validator/jwt:/jwt
+      - ${DIVA_DATA_FOLDER:-.}/prysm/validator/jwt:/jwt
     environment:
       - VALIDATOR_RKM_API=http://validator:7500
       - DIVA_W3S_API=http://diva:9000


### PR DESCRIPTION
This is a backwards-compatible change that introduces the `DIVA_DATA_FOLDER` environment variable that can be used to set the base path where the Diva (and client) data should go.

This is an alternative to #19 that is easier to implement in a backwards compatible way.