### PR TITLE
Use version vars; track stable client/metrics releases

### DIFF
--- a/docker-compose-lodestar-vc.yml
+++ b/docker-compose-lodestar-vc.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   diva:
-    image: diva/diva:v23.8.7
+    image: diva/diva:${DIVA_VERSION:-v23.8.7}
     platform: linux/amd64
     container_name: diva
     hostname: diva
@@ -56,7 +56,7 @@ services:
           - vc-rkm
 
   reloader:
-    image: diva/reloader:v23.8.0
+    image: diva/reloader:${RELOADER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: reloader
     hostname: reloader
@@ -78,7 +78,7 @@ services:
         exec /bin/sh /reload.sh
 
   operator-ui:
-    image: diva/operator-ui:v23.8.3
+    image: diva/operator-ui:${OPERATOR_UI_VERSION:-v23.8.3}
     platform: linux/amd64
     container_name: operator-ui
     restart: unless-stopped
@@ -87,13 +87,13 @@ services:
 
   # Telemetry configuration
   jaeger:
-    image: diva/jaeger:v23.8.0
+    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: jaeger
     restart: unless-stopped
 
   vector:
-    image: diva/vector:v23.8.0
+    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: vector
     restart: unless-stopped

--- a/docker-compose-with-clients-metrics.yml
+++ b/docker-compose-with-clients-metrics.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   diva:
-    image: diva/diva:v23.8.7
+    image: diva/diva:${DIVA_VERSION:-v23.8.7}
     platform: linux/amd64
     container_name: diva
     hostname: diva
@@ -29,7 +29,7 @@ services:
       - 30000:30000
 
   validator:
-    image: gcr.io/prysmaticlabs/prysm/validator:v4.0.7
+    image: gcr.io/prysmaticlabs/prysm/validator:stable
     platform: linux/amd64
     container_name: validator
     hostname: validator
@@ -58,7 +58,7 @@ services:
           - vc-rkm
 
   reloader:
-    image: diva/reloader:v23.8.0
+    image: diva/reloader:${RELOADER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: reloader
     hostname: reloader
@@ -71,7 +71,7 @@ services:
       - SYNC_PERIOD=600
 
   operator-ui:
-    image: diva/operator-ui:v23.8.3
+    image: diva/operator-ui:${OPERATOR_UI_VERSION:-v23.8.3}
     platform: linux/amd64
     container_name: operator-ui
     restart: unless-stopped
@@ -80,13 +80,13 @@ services:
 
   # Telemetry configuration
   jaeger:
-    image: diva/jaeger:v23.8.0
+    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: jaeger
     restart: unless-stopped
 
   vector:
-    image: diva/vector:v23.8.0
+    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: vector
     restart: unless-stopped
@@ -97,7 +97,7 @@ services:
 
   # Ethereum clients
   geth:
-    image: ethereum/client-go:v1.12.1
+    image: ethereum/client-go:stable
     container_name: geth
     restart: unless-stopped
     stop_grace_period: 1m
@@ -126,7 +126,7 @@ services:
       - "30303:30303/udp"
 
   beacon:
-    image: prysmaticlabs/prysm-beacon-chain:v4.0.7
+    image: prysmaticlabs/prysm-beacon-chain:stable
     user: root
     container_name: beacon
     restart: unless-stopped
@@ -158,7 +158,7 @@ services:
       - 127.0.0.1:8080:8080
 
   prometheus:
-    image: prom/prometheus:v2.46.0
+    image: prom/prometheus:latest
     user: root
     container_name: prometheus
     hostname: prometheus
@@ -171,14 +171,14 @@ services:
       - ${DIVA_DATA_FOLDER:-.}/prometheus/data:/prometheus
 
   node-exporter:
-    image: prom/node-exporter:v1.6.1
+    image: prom/node-exporter:latest
     container_name: node-exporter
     ports:
       - 127.0.0.1:9100:9100
     restart: always
 
   grafana:
-    image: grafana/grafana:10.0.3
+    image: grafana/grafana:latest
     user: root
     container_name: grafana
     hostname: grafana

--- a/docker-compose-with-clients.yml
+++ b/docker-compose-with-clients.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   diva:
-    image: diva/diva:v23.8.7
+    image: diva/diva:${DIVA_VERSION:-v23.8.7}
     platform: linux/amd64
     container_name: diva
     hostname: diva
@@ -29,7 +29,7 @@ services:
       - 30000:30000
 
   validator:
-    image: gcr.io/prysmaticlabs/prysm/validator:v4.0.7
+    image: gcr.io/prysmaticlabs/prysm/validator:stable
     platform: linux/amd64
     container_name: validator
     hostname: validator
@@ -58,7 +58,7 @@ services:
           - vc-rkm
 
   reloader:
-    image: diva/reloader:v23.8.0
+    image: diva/reloader:${RELOADER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: reloader
     hostname: reloader
@@ -71,7 +71,7 @@ services:
       - SYNC_PERIOD=600
 
   operator-ui:
-    image: diva/operator-ui:v23.8.3
+    image: diva/operator-ui:${OPERATOR_UI_VERSION:-v23.8.3}
     platform: linux/amd64
     container_name: operator-ui
     restart: unless-stopped
@@ -80,13 +80,13 @@ services:
 
   # Telemetry configuration
   jaeger:
-    image: diva/jaeger:v23.8.0
+    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: jaeger
     restart: unless-stopped
 
   vector:
-    image: diva/vector:v23.8.0
+    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: vector
     restart: unless-stopped
@@ -97,7 +97,7 @@ services:
 
   # Ethereum clients
   geth:
-    image: ethereum/client-go:v1.12.1
+    image: ethereum/client-go:stable
     container_name: geth
     restart: unless-stopped
     stop_grace_period: 1m
@@ -126,7 +126,7 @@ services:
       - "30303:30303/udp"
 
   beacon:
-    image: prysmaticlabs/prysm-beacon-chain:v4.0.7
+    image: prysmaticlabs/prysm-beacon-chain:stable
     user: root
     container_name: beacon
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   diva:
-    image: diva/diva:v23.8.7
+    image: diva/diva:${DIVA_VERSION:-v23.8.7}
     platform: linux/amd64
     container_name: diva
     hostname: diva
@@ -29,7 +29,7 @@ services:
       - 30000:30000
 
   validator:
-    image: gcr.io/prysmaticlabs/prysm/validator:v4.0.7
+    image: gcr.io/prysmaticlabs/prysm/validator:stable
     platform: linux/amd64
     container_name: validator
     hostname: validator
@@ -58,7 +58,7 @@ services:
           - vc-rkm
 
   reloader:
-    image: diva/reloader:v23.8.0
+    image: diva/reloader:${RELOADER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: reloader
     hostname: reloader
@@ -71,7 +71,7 @@ services:
       - SYNC_PERIOD=600
 
   operator-ui:
-    image: diva/operator-ui:v23.8.3
+    image: diva/operator-ui:${OPERATOR_UI_VERSION:-v23.8.3}
     platform: linux/amd64
     container_name: operator-ui
     restart: unless-stopped
@@ -80,13 +80,13 @@ services:
 
   # Telemetry configuration
   jaeger:
-    image: diva/jaeger:v23.8.0
+    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: jaeger
     restart: unless-stopped
 
   vector:
-    image: diva/vector:v23.8.0
+    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
     platform: linux/amd64
     container_name: vector
     restart: unless-stopped


### PR DESCRIPTION
This does two things:
- Use version vars introduced in .env, with defaults if not present
- Use stable releases of clients and metrics containers, instead of tracking specific versions

That second change frees you up to focus on Diva versions rather than checking supporting versions all the time - but I can also see an argument for not doing this and seeking specific versions for clients and metrics containers instead.