### PR TITLE
More guidance for env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,20 @@ OPERATOR_UI_VERSION=v23.8.4 # Change this (version of the Diva operator UI)
 JAEGER_VERSION=v23.8.0 # Change this (version of the Diva Jaeger)
 VECTOR_VERSION=v23.8.0 # Change this (version of the Diva vector)
 
+# How you set this depends on where your Ethereum node runs. 
+# If you use the -with-clients compose file, use these
+#EXECUTION_CLIENT_URL=ws://geth:8546
+#CONSENSUS_CLIENT_URL=http://beacon:3500
+#BEACON_RPC_PROVIDER=beacon:4000
+# If you use ext-network.yml with RocketPool, use these
+#EXECUTION_CLIENT_URL=ws://eth1:8546
+#CONSENSUS_CLIENT_URL=http://eth2:5052
+#BEACON_RPC_PROVIDER=eth2:4000
+# If you connect to a node in Eth Docker, use these
+#EXECUTION_CLIENT_URL=ws://execution:8546
+#CONSENSUS_CLIENT_URL=http://consensus:5052
+#BEACON_RPC_PROVIDER=consensus:4000
+# If your Ethereum node runs in systemd, e.g. Somer, use these 
 EXECUTION_CLIENT_URL=ws://HOST_IP:PORT  # Change this (execution RPC WebSocket, geth example: ws://HOST_IP:8546)
 CONSENSUS_CLIENT_URL=http://HOST_IP:PORT  # Change this (consensus REST API, prysm example: http://HOST_IP:3500)
 BEACON_RPC_PROVIDER=HOST_IP:PORT # Change this (consensus RPC, prysm example: HOST_IP:4000 please note there is not http://)
@@ -17,6 +31,6 @@ DIVA_API_KEY=changeThis  # Change this (API key for the operator UI)
 DIVA_VAULT_PASSWORD=vaultPassword # Change this (password for the encrypted vault)
 TESTNET_USERNAME=username-address  # Change this (recommended to username of the operator and ethereum address)
 
-# Optional: the path where you want to store the data of Diva and potentially the consensus and execution clients managed by it's stack
+# Optional: the path where you want to store the data of Diva and potentially the consensus and execution clients managed by its stack
 # default value when this variable is unset is the current directory
 DIVA_DATA_FOLDER=


### PR DESCRIPTION
The dev-ports you just merged, on further thought, will break things for people who use -with-clients and the host IP, instead of names.

They'd need to add dev-ports-with-clients.yml to their COMPOSE_FILE *or* they can adjust so they use docker networking, which is arguably cleaner.

This PR gives more guidance inside .env.example as to how these variables work
