### PR TITLE
Use gcr for beacon

### DIFF
--- a/docker-compose-with-clients-metrics.yml
+++ b/docker-compose-with-clients-metrics.yml
@@ -121,7 +121,7 @@ services:
       - "30303:30303/udp"
 
   beacon:
-    image: prysmaticlabs/prysm-beacon-chain:stable
+    image: gcr.io/prysmaticlabs/prysm/beacon-chain:stable
     user: root
     container_name: beacon
     restart: unless-stopped

--- a/docker-compose-with-clients.yml
+++ b/docker-compose-with-clients.yml
@@ -121,7 +121,7 @@ services:
       - "30303:30303/udp"
 
   beacon:
-    image: prysmaticlabs/prysm-beacon-chain:stable
+    image: gcr.io/prysmaticlabs/prysm/beacon-chain:stable
     user: root
     container_name: beacon
     restart: unless-stopped


### PR DESCRIPTION
For consistency, use gcr.io as the repo for the prysm beacon, the same way it's already being used for the validator