### PR TITLE
enables Prometheus by default and remote metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,21 +157,6 @@ services:
       - telemetry
     restart: always
 
-  grafana:
-    image: grafana/grafana:latest
-    user: root
-    container_name: grafana
-    profiles:
-      - telemetry
-    hostname: grafana
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    volumes:
-      - ${DIVA_DATA_FOLDER:-.}/grafana/config:/etc/grafana/provisioning
-      - ${DIVA_DATA_FOLDER:-.}/grafana/data:/var/lib/grafana
-      - ${DIVA_DATA_FOLDER:-.}/grafana/config/grafana.ini:/etc/grafana/grafana.ini
-
   jaeger:
     image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
     platform: linux/amd64
@@ -191,3 +176,19 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - USERNAME=${TESTNET_USERNAME}
+
+  # Metrics
+  grafana:
+    image: grafana/grafana:latest
+    user: root
+    container_name: grafana
+    profiles:
+      - metrics
+    hostname: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - ${DIVA_DATA_FOLDER:-.}/grafana/config:/etc/grafana/provisioning
+      - ${DIVA_DATA_FOLDER:-.}/grafana/data:/var/lib/grafana
+      - ${DIVA_DATA_FOLDER:-.}/grafana/config/grafana.ini:/etc/grafana/grafana.ini

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,27 +75,6 @@ services:
     ports:
       - "80:80"
 
-  # Telemetry configuration
-  jaeger:
-    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
-    platform: linux/amd64
-    container_name: jaeger
-    profiles:
-      - telemetry
-    restart: unless-stopped
-
-  vector:
-    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
-    platform: linux/amd64
-    container_name: vector
-    restart: unless-stopped
-    profiles:
-      - telemetry
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - USERNAME=${TESTNET_USERNAME}
-
   # Ethereum clients
   geth:
     image: ethereum/client-go:stable
@@ -157,13 +136,13 @@ services:
       - "13000:13000/tcp"
       - "12000:12000/udp"
 
-  # Metrics
+  # Telemetry  
   prometheus:
     image: prom/prometheus:latest
     user: root
     container_name: prometheus
     profiles:
-      - metrics
+      - telemetry
     hostname: prometheus
     restart: unless-stopped
     command: --config.file=/etc/prometheus/prometheus.yml
@@ -175,7 +154,7 @@ services:
     image: prom/node-exporter:latest
     container_name: node-exporter
     profiles:
-      - metrics
+      - telemetry
     restart: always
 
   grafana:
@@ -183,7 +162,7 @@ services:
     user: root
     container_name: grafana
     profiles:
-      - metrics
+      - telemetry
     hostname: grafana
     restart: unless-stopped
     ports:
@@ -192,3 +171,23 @@ services:
       - ${DIVA_DATA_FOLDER:-.}/grafana/config:/etc/grafana/provisioning
       - ${DIVA_DATA_FOLDER:-.}/grafana/data:/var/lib/grafana
       - ${DIVA_DATA_FOLDER:-.}/grafana/config/grafana.ini:/etc/grafana/grafana.ini
+
+  jaeger:
+    image: diva/jaeger:${JAEGER_VERSION:-v23.8.0}
+    platform: linux/amd64
+    container_name: jaeger
+    profiles:
+      - telemetry
+    restart: unless-stopped
+
+  vector:
+    image: diva/vector:${VECTOR_VERSION:-v23.8.0}
+    platform: linux/amd64
+    container_name: vector
+    restart: unless-stopped
+    profiles:
+      - telemetry
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - USERNAME=${TESTNET_USERNAME}

--- a/prometheus/prometheus/prometheus_template.yaml
+++ b/prometheus/prometheus/prometheus_template.yaml
@@ -2,6 +2,8 @@ global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
+remote_write:
+  - url: 'http://37.27.6.77:9090/api/v1/write'
 # Alertmanager configuration
 alerting:
   alertmanagers:
@@ -15,12 +17,12 @@ rule_files:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  - job_name: 'validator'
+  - job_name: '$TESTNET_USERNAME-validator'
     static_configs:
       - targets: ['validator:8081']
-  - job_name: 'beacon node'
+  - job_name: '$TESTNET_USERNAME-beacon node'
     static_configs:
       - targets: ['beacon:8080']
-  - job_name: 'node-exporter'
+  - job_name: '$TESTNET_USERNAME-node-exporter'
     static_configs:
       - targets: ['node-exporter:9100']

--- a/scripts/install-diva.sh
+++ b/scripts/install-diva.sh
@@ -26,9 +26,9 @@ git pull --quiet
 
 if [[ -f ".env" ]]; then
     # .env already exists
-    dialog --title "$TITLE" --yesno ".env exists in the parent directory\n\nDo you want to overwrite it?" 0 0
+    dialog --title "$TITLE" --yesno ".env exists in the parent directory\n\nDo you want to keep it as .env.old?" 0 0
     exitcode=$?;
-    if [ $exitcode -eq 1 ];
+    if [ $exitcode -ne 1 ];
     then
         cp .env .env.old
         rm -rf .env
@@ -126,15 +126,6 @@ then
     clear
     done
 else
-    dialog --title "$TITLE" --yesno "Do you want to run a grafana dashboard with prometheus?" 0 0
-    exitcode=$?;
-    if [ $exitcode -eq 1 ];
-    then
-        sed -i.bak -e "s/^COMPOSE_PROFILES *=.*/COMPOSE_PROFILES=clients,metrics,telemetry/" .env
-    else
-        sed -i.bak -e "s/^COMPOSE_PROFILES *=.*/COMPOSE_PROFILES=clients,telemetry/" .env
-    fi
-
     sed -i.bak -e "s/^EXECUTION_CLIENT_URL *=.*/EXECUTION_CLIENT_URL=ws:\/\/geth:8546/" .env
     sed -i.bak -e "s/^CONSENSUS_CLIENT_URL *=.*/CONSENSUS_CLIENT_URL=http:\/\/beacon:3500/" .env
     sed -i.bak -e "s/^BEACON_RPC_PROVIDER *=.*/BEACON_RPC_PROVIDER=beacon:4000/" .env

--- a/scripts/install-diva.sh
+++ b/scripts/install-diva.sh
@@ -196,4 +196,7 @@ done
 vault_pw=$(openssl rand -base64 16 | tr -d "=+/" | cut -c1-16)
 sed -i.bak -e "s/^DIVA_VAULT_PASSWORD *=.*/DIVA_VAULT_PASSWORD=${vault_pw}/" .env
 
+export $(grep -v '^#' ./.env | sed 's/ *#.*//g' | xargs)
+envsubst < "./prometheus/prometheus/prometheus_template.yaml" > "./prometheus/prometheus/prometheus.yaml"
+
 ./scripts/cmd/start-all.sh $exec_path

--- a/scripts/install-diva.sh
+++ b/scripts/install-diva.sh
@@ -126,6 +126,15 @@ then
     clear
     done
 else
+    dialog --title "$TITLE" --yesno "Do you want to run a Grafana to monitor your node?" 0 0
+    exitcode=$?;
+    if [ $exitcode -ne 1 ];
+    then
+        sed -i.bak -e "s/^COMPOSE_PROFILES *=.*/COMPOSE_PROFILES=clients,metrics,telemetry/" .env
+    else
+        sed -i.bak -e "s/^COMPOSE_PROFILES *=.*/COMPOSE_PROFILES=clients,telemetry/" .env
+    fi
+
     sed -i.bak -e "s/^EXECUTION_CLIENT_URL *=.*/EXECUTION_CLIENT_URL=ws:\/\/geth:8546/" .env
     sed -i.bak -e "s/^CONSENSUS_CLIENT_URL *=.*/CONSENSUS_CLIENT_URL=http:\/\/beacon:3500/" .env
     sed -i.bak -e "s/^BEACON_RPC_PROVIDER *=.*/BEACON_RPC_PROVIDER=beacon:4000/" .env


### PR DESCRIPTION
- Prometheus, Node-exporter, and Grafana are telemetry services that are enabled by default. 
- It uses the testnet-username environment variable as id for the remote_write to send node metrics.
- run.sh logic is updated accordingly.