### PR TITLE
The testnet link does not lead anywhere, it needs to be updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This repository contains the necessary compose files to participate in the Diva 
 
 # Testnet instructions
 
-To join the testnet, follow the instructions described in the [**Diva testnet documentation**](https://docs.shamirlabs.org/testnet/intro)
+To join the testnet, follow the instructions described in the [**Diva testnet documentation**]([https://docs.shamirlabs.org/testnet/intro](https://docs.shamirlabs.org/diva/testnet/install/scripts/docker)https://docs.shamirlabs.org/diva/testnet/install/scripts/docker)


### PR DESCRIPTION
While checking out the documentation, I found out the link for getting started with the testnet does not lead anywhere. 

I made corrections to it, but I guess the link I used might not be the official one, it could be amended. 

