### PR TITLE
Add support for Teku validator.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,8 @@ TESTNET_USERNAME=username-operatoraddress  # Change this (recommended to usernam
 # Optional: the path where you want to store the data of Diva and potentially the consensus and execution clients managed by its stack
 # default value when this variable is unset is the current directory
 DIVA_DATA_FOLDER=
+
+# Optional: set the runtime user for diva, validator and reloader containers
+# if you set user different that root, please make sure respective directories are created in advance and chown is applied (.diva ; vc-clients/teku/validator/key-manager)
+# as of now this is used only for teku vc
+DIVA_USER=0:0

--- a/docker-compose-teku-vc.yml
+++ b/docker-compose-teku-vc.yml
@@ -1,0 +1,96 @@
+version: '3.8'
+
+services:
+
+  diva:
+    extends:
+      file: docker-compose.yml
+      service: diva
+
+  validator:
+    image: consensys/teku:latest
+    platform: linux/amd64
+    container_name: validator
+    hostname: validator
+    restart: unless-stopped
+    user: ${DIVA_USER}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ ! -f /opt/teku/data/validator_api_key.password ]; then
+            rm -f /opt/teku/data/validator_api_key.keystore
+            cat /proc/sys/kernel/random/uuid > /opt/teku/data/validator_api_key.password
+            keytool -genkeypair -keystore /opt/teku/data/validator_api_key.keystore -storetype PKCS12 -keyalg RSA -keysize 2048 -validity 10000 \
+                -dname "cn=localhost, ou=Unknown, o=Unknown, c=UU" \
+                -storepass `cat /opt/teku/data/validator_api_key.password`
+            chmod 640 /opt/teku/data/validator_api_key.password
+            chmod 640 /opt/teku/data/validator_api_key.keystore
+            echo "Keystore created."
+        fi
+        echo "wait 10s for diva to start."
+        sleep 10
+        exec /opt/teku/bin/teku "$@"
+    command:
+      [
+        "",
+        "vc",
+        "--network=goerli",
+        "--logging=DEBUG",
+        "--data-base-path=/opt/teku/data",
+        "--beacon-node-api-endpoint=${CONSENSUS_CLIENT_URL}",
+        "--validators-external-signer-url=http://diva:9000",
+        "--validators-external-signer-public-keys=http://diva:9000/api/v1/eth2/publicKeys",
+        "--validators-proposer-default-fee-recipient=0x3660650755B12555BBAc2284c2391ccBB4EBFDD6",
+        "--metrics-enabled=true",
+        "--metrics-host-allowlist=*",
+        "--metrics-interface=0.0.0.0",
+        "--metrics-port=8081",
+        "--validator-api-enabled=true",
+        "--validator-api-host-allowlist=*",
+        "--validator-api-interface=0.0.0.0",
+        "--validator-api-port=5052",
+        "--validator-api-keystore-file=/opt/teku/data/validator_api_key.keystore",
+        "--validator-api-keystore-password-file=/opt/teku/data/validator_api_key.password"
+      ]
+    volumes:
+      - "./vc-clients/teku:/opt/teku/data"
+
+  reloader:
+    image: diva/reloader:${RELOADER_VERSION:-v23.8.0}
+    platform: linux/amd64
+    container_name: reloader
+    hostname: reloader
+    restart: unless-stopped
+    user: ${DIVA_USER}
+    volumes:
+      - ${DIVA_DATA_FOLDER:-.}/vc-clients/teku/validator/key-manager:/jwt
+    environment:
+      - VALIDATOR_RKM_API=http://validator:5052
+      - DIVA_W3S_API=http://diva:9000
+      - SYNC_PERIOD=600
+    entrypoint: ["/bin/sh","-c"]
+    command:
+      - |
+        while [ ! -f /jwt/validator-api-bearer ]; do
+          sleep 1
+          echo "Waiting for Teku to create keymanager auth token"
+        done
+        cp /jwt/validator-api-bearer /jwt/auth-token
+        exec /bin/sh /reload.sh
+
+  operator-ui:
+    extends:
+      file: docker-compose.yml
+      service: operator-ui
+
+# Telemetry configuration
+  jaeger:
+    extends:
+      file: docker-compose.yml
+      service: jaeger
+
+  vector:
+    extends:
+      file: docker-compose.yml
+      service: vector

--- a/reloader/reload.sh
+++ b/reloader/reload.sh
@@ -8,8 +8,17 @@
 
 # Local variables
 VALIDATOR_RKM_API_TOKEN_PATH="/jwt/auth-token"
-W3S_KEYS_FILE="/w3skeys.json"
+W3S_KEYS_FILE="/tmp/w3skeys.json"
 VALIDATOR_RKM_API_TOKEN=$(cat $VALIDATOR_RKM_API_TOKEN_PATH | sed -n '2 p')
+
+if [ -z "$VALIDATOR_RKM_API_TOKEN" ]; then
+    VALIDATOR_RKM_API_TOKEN=$(cat $VALIDATOR_RKM_API_TOKEN_PATH | sed -n '1 p')
+fi
+
+if [ -z "$VALIDATOR_RKM_API_TOKEN" ]; then
+    echo "No Validator API token found, cannot continue."
+    exit 1
+fi
 
 while [ true ]; do
     echo "----------------------------------"


### PR DESCRIPTION
- generation of the keystore - change entrypoint do the work and delegate back
- default fee recipient address - get from BN as defined in docker.compose.yml
- metrics port - set to 8081 so phometheus can scrpe
- reloader - add fallback to obtain access token