### PR TITLE
Fix bug: it's `ws://geth:8546` not `ws://eth:8546`

### DIFF
--- a/scripts/install-diva.sh
+++ b/scripts/install-diva.sh
@@ -135,7 +135,7 @@ else
         sed -i.bak -e "s/^COMPOSE_PROFILES *=.*/COMPOSE_PROFILES=clients,telemetry/" .env
     fi
 
-    sed -i.bak -e "s,^EXECUTION_CLIENT_URL *=.*,EXECUTION_CLIENT_URL=ws://eth:8546," .env
+    sed -i.bak -e "s,^EXECUTION_CLIENT_URL *=.*,EXECUTION_CLIENT_URL=ws://geth:8546," .env
     sed -i.bak -e "s,^CONSENSUS_CLIENT_URL *=.*,CONSENSUS_CLIENT_URL=http://beacon:3500," .env
     sed -i.bak -e "s,^BEACON_RPC_PROVIDER *=.*,BEACON_RPC_PROVIDER=beacon:4000," .env
 fi


### PR DESCRIPTION
In `docker-compose.yml`

```yaml
services:
 ...

  # Ethereum clients
  geth:
    image: ethereum/client-go:stable
    container_name: geth
```