### PR TITLE
Fix `./run.sh: line 67: break: only meaningful in a for, while, or until loop`

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -64,6 +64,5 @@ case $CHOICE in
             ;;
         8)
             echo "Not implemented"
-            break
             ;;
 esac


### PR DESCRIPTION
Before

```
$ ./run.sh
Not implemented
./run.sh: line 67: break: only meaningful in a `for', `while', or `until' loop
```

After

```
$ ./run.sh
Not implemented
```